### PR TITLE
fix: support non-CUDA/Ascend backend by guarding platform-specific code and using host-side fallbacks

### DIFF
--- a/jittor_geometric/dataloader/temporal_dataloader.py
+++ b/jittor_geometric/dataloader/temporal_dataloader.py
@@ -288,7 +288,10 @@ def get_neighbor_sampler(data, sample_neighbor_strategy: str = 'uniform', time_s
     :param seed: int, random seed
     :return:
     """
-    max_node_id = max(data.src.max(), data.dst.max())
+    # NOTE: reduce on numpy, not jittor Var. On Ascend/ACL, Var.max() over
+    # integer node-id tensors hits aclnnAmax ERROR 161002 (param invalid) and
+    # returns a wrong (too small) value, making adj_list too short -> IndexError.
+    max_node_id = int(max(np.array(data.src).max(), np.array(data.dst).max()))
     # the adjacency vector stores edges for each node (source or destination), undirected
     # adj_list, list of list, where each element is a list of triple tuple (node_id, edge_id, timestamp)
     # the list at the first position in adj_list is empty
@@ -356,5 +359,9 @@ class TemporalDataLoader:
                 batch.neg_dst = neg_dst
                 n_ids += [batch.neg_dst]
 
-            batch.n_id = jt.concat(n_ids).unique()
+            # NOTE: do unique on numpy. jt.Var.unique() lowers to a jt.code
+            # custom op flagged _cuda, which on Ascend/ACL hits "op code not
+            # supported". n_ids are integer node ids (no grad), so numpy is fine.
+            _n_id_np = np.unique(np.concatenate([np.array(t).reshape(-1) for t in n_ids]))
+            batch.n_id = jt.array(_n_id_np)
             yield batch

--- a/jittor_geometric/ops/cpp/aggregate_op.cc
+++ b/jittor_geometric/ops/cpp/aggregate_op.cc
@@ -11,7 +11,9 @@ namespace jittor {
     AggregateOp::AggregateOp(Var* outputVar_, Var* x_, Var* indices_,Var* offset_,Var* weight_,bool forward_) :
     outputVar(outputVar_),x(x_),indices(indices_), offset(offset_),weight(weight_),forward(forward_){
         flags.set(NodeFlags::_cpu, 1);
+#ifdef IS_CUDA
         flags.set(NodeFlags::_cuda, 1);
+#endif
         output = create_output(nullptr,x->dtype());
     }
 

--- a/jittor_geometric/ops/cpp/aggregate_op.h
+++ b/jittor_geometric/ops/cpp/aggregate_op.h
@@ -5,7 +5,9 @@
  */
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <cstdlib>
 #include <thread>
 namespace jittor {

--- a/jittor_geometric/ops/cpp/cootocsc_op.h
+++ b/jittor_geometric/ops/cpp/cootocsc_op.h
@@ -5,7 +5,9 @@
  */
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <cstdlib>
 #include <thread>
 namespace jittor {

--- a/jittor_geometric/ops/cpp/cootocsr_op.h
+++ b/jittor_geometric/ops/cpp/cootocsr_op.h
@@ -5,7 +5,9 @@
  */
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <cstdlib>
 #include <thread>
 namespace jittor {

--- a/jittor_geometric/ops/cpp/csctocsr_op.h
+++ b/jittor_geometric/ops/cpp/csctocsr_op.h
@@ -5,7 +5,9 @@
 
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <iostream>
 #include <vector>
 #include <algorithm>

--- a/jittor_geometric/ops/cpp/edgesoftmax_op.cc
+++ b/jittor_geometric/ops/cpp/edgesoftmax_op.cc
@@ -5,7 +5,9 @@
  */
 
 #include  "var.h"
+#ifdef JIT_cuda
 #include  <cuda.h>
+#endif
 #include  "edgesoftmax_op.h"
 #ifdef JIT_cuda
 // #include <cub/device/device_segmented_radix_sort.cuh>

--- a/jittor_geometric/ops/cpp/edgesoftmax_op.h
+++ b/jittor_geometric/ops/cpp/edgesoftmax_op.h
@@ -6,7 +6,9 @@
 
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <cstdlib>
 #include <thread>
 #include <math.h>

--- a/jittor_geometric/ops/cpp/edgesoftmaxbackward_op.h
+++ b/jittor_geometric/ops/cpp/edgesoftmaxbackward_op.h
@@ -7,7 +7,9 @@
 
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <cstdlib>
 #include <thread>
 #include <math.h>

--- a/jittor_geometric/ops/cpp/edgetovertex_op.h
+++ b/jittor_geometric/ops/cpp/edgetovertex_op.h
@@ -6,7 +6,9 @@
 
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <cstdlib>
 #include <thread>
 namespace jittor {

--- a/jittor_geometric/ops/cpp/getweight_op.h
+++ b/jittor_geometric/ops/cpp/getweight_op.h
@@ -4,7 +4,9 @@
  */
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <iostream>
 #include <vector>
 #include <algorithm>

--- a/jittor_geometric/ops/cpp/gpuinitco_op.h
+++ b/jittor_geometric/ops/cpp/gpuinitco_op.h
@@ -4,7 +4,9 @@
  */
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <iostream>
 #include <vector>
 #include <algorithm>

--- a/jittor_geometric/ops/cpp/sampleprocessing_op.cc
+++ b/jittor_geometric/ops/cpp/sampleprocessing_op.cc
@@ -4,8 +4,10 @@
  */
 #include "var.h"
 #include "sampleprocessing_op.h"
+#ifdef JIT_cuda
 #include "helper_cuda.h"
 #include <curand_kernel.h>
+#endif
 #include <stdint.h>
 
 #include <algorithm>

--- a/jittor_geometric/ops/cpp/sampleprocessing_op.h
+++ b/jittor_geometric/ops/cpp/sampleprocessing_op.h
@@ -4,7 +4,9 @@
  */
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <iostream>
 #include <vector>
 #include <algorithm>

--- a/jittor_geometric/ops/cpp/scattertoedge_op.h
+++ b/jittor_geometric/ops/cpp/scattertoedge_op.h
@@ -6,7 +6,9 @@
 
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <cstdlib>
 #include <thread>
 namespace jittor {

--- a/jittor_geometric/ops/cpp/toundirected_op.h
+++ b/jittor_geometric/ops/cpp/toundirected_op.h
@@ -6,7 +6,9 @@
 
 #pragma once
 #include "op.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
+#endif
 #include <iostream>
 #include <vector>
 #include <algorithm>

--- a/jittor_geometric/ops/spmmcoo.py
+++ b/jittor_geometric/ops/spmmcoo.py
@@ -13,11 +13,12 @@ module_path = os.path.dirname(__file__)
 # src = os.path.join(module_path, "cpp/spmmcoo_op.cc")
 # header = os.path.join(module_path, "cpp/spmmcoo_op.h")
 # spmmcoo_op = jt.compile_custom_ops((src, header)) 
-from jittor.compile_extern import cusparse_ops # latest jittor
+# moved to lazy import inside SpmmCooFunc.execute/grad (cusparse unavailable on Ascend)
 # Run the test
 jt.flags.use_cuda=1
 class SpmmCooFunc(Function):
     def execute(self,x,edge_index,edge_weight,trans_A,trans_B):
+        from jittor.compile_extern import cusparse_ops
         self.edge_index=edge_index
         row_indices=edge_index[0,:]
         col_indices=edge_index[1,:]
@@ -35,6 +36,7 @@ class SpmmCooFunc(Function):
         return output
 
     def grad(self, grad_output):
+        from jittor.compile_extern import cusparse_ops
         output_grad=jt.zeros(self.v_num,self.feature_dim)
         cusparse_ops.cusparse_spmmcoo(output_grad,grad_output,self.row_indices,self.col_indices,self.edge_weight,self.v_num,self.v_num).fetch_sync()
         return output_grad,None,None

--- a/jittor_geometric/ops/spmmcsr.py
+++ b/jittor_geometric/ops/spmmcsr.py
@@ -11,7 +11,7 @@ from jittor import Function
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from jittor_geometric.data import CSR
 module_path = os.path.dirname(__file__)
-from jittor.compile_extern import cusparse_ops
+# moved to lazy import inside SpmmCsrFunc.execute/grad (cusparse unavailable on Ascend)
 # src = os.path.join(module_path, "cpp/spmmcsr_op.cc")
 # header = os.path.join(module_path, "cpp/spmmcsr_op.h")
 # spmmcsr_op = jt.compile_custom_ops((src, header))
@@ -20,6 +20,7 @@ from jittor.compile_extern import cusparse_ops
 jt.flags.use_cuda=1
 class SpmmCsrFunc(Function):
     def execute(self,x,csr,trans_A,trans_B):
+        from jittor.compile_extern import cusparse_ops
         self.csr=csr
         feature_dim=jt.size(x,1)        
         v_num=jt.size(csr.row_offset,0)-1
@@ -33,6 +34,7 @@ class SpmmCsrFunc(Function):
         return output
 
     def grad(self, grad_output):
+        from jittor.compile_extern import cusparse_ops
         output_grad=jt.zeros(self.v_num,self.feature_dim)
         cusparse_ops.cusparse_spmmcsr(output_grad,grad_output,self.csr.column_indices,self.csr.edge_weight,self.csr.row_offset,self.v_num,self.v_num,self.trans_A,self.trans_B).fetch_sync()
         # spmmcsr_op.spmmcsr(output_grad,grad_output,self.csr.column_indices,self.csr.edge_weight,self.csr.row_offset,self.v_num,self.v_num).fetch_sync()

--- a/jittor_geometric/utils/loop.py
+++ b/jittor_geometric/utils/loop.py
@@ -6,6 +6,31 @@ from .num_nodes import maybe_num_nodes
 from jittor import Var, init
 
 
+def _select_columns_by_mask(edge_index, mask):
+    # Equivalent to a 2-D masked column select on dim 1 (edge_index[:, mask]).
+    # The (slice, bool-Var) mixed indexing form is unsupported on the Jittor
+    # ACL (Ascend) backend, and the native bool-Var index is also rejected on
+    # the CPU backend. edge_index here is a small host-side (2, E) tensor, so we
+    # resolve the selection on the host via NumPy: this is fully device-agnostic
+    # and works identically on CPU and NPU.
+    import numpy as np
+    idx = np.nonzero(np.asarray(mask).reshape(-1))[0]
+    return jt.array(np.asarray(edge_index)[:, idx])
+
+
+def _mask_select_1d(x, mask):
+    # Equivalent to x[mask] for a 1-D boolean mask. The native bool-Var index
+    # is rejected on the Jittor CPU backend ("convert bool slice into
+    # jt.array"); the ACL backend accepts a bool-Var index but rejects an
+    # integer-index Var here (GetItemACL -> jt.Var(int_idx) raises a device
+    # memcpy param error). These are small host-side weight/index tensors, so
+    # resolve the selection on the host via NumPy: fully device-agnostic and
+    # identical on CPU and NPU.
+    import numpy as np
+    idx = np.nonzero(np.asarray(mask).reshape(-1))[0]
+    return jt.array(np.asarray(x)[idx])
+
+
 def contains_self_loops(edge_index):
     r"""Returns :obj:`True` if the graph given by :attr:`edge_index` contains
     self-loops.
@@ -31,7 +56,7 @@ def remove_self_loops(edge_index, edge_attr: Optional[Var] = None):
     :rtype: (:class:`Var int32`, :class:`Var`)
     """
     mask = edge_index[0] != edge_index[1]
-    edge_index = edge_index[:, mask]
+    edge_index = _select_columns_by_mask(edge_index, mask)
     if edge_attr is None:
         return edge_index, None
     else:
@@ -53,9 +78,9 @@ def segregate_self_loops(edge_index, edge_attr: Optional[Var] = None):
     mask = edge_index[0] != edge_index[1]
     inv_mask = jt.logical_not(mask)
 
-    loop_edge_index = edge_index[:, inv_mask]
+    loop_edge_index = _select_columns_by_mask(edge_index, inv_mask)
     loop_edge_attr = None if edge_attr is None else edge_attr[inv_mask]
-    edge_index = edge_index[:, mask]
+    edge_index = _select_columns_by_mask(edge_index, mask)
     edge_attr = None if edge_attr is None else edge_attr[mask]
 
     return edge_index, edge_attr, loop_edge_index, loop_edge_attr
@@ -123,14 +148,14 @@ def add_remaining_self_loops(edge_index,
 
     loop_index = jt.arange(0, N, dtype=row.dtype)
     loop_index = loop_index.unsqueeze(0).repeat(2, 1)
-    edge_index = jt.concat([edge_index[:, mask], loop_index], dim=1)
+    edge_index = jt.concat([_select_columns_by_mask(edge_index, mask), loop_index], dim=1)
 
     if edge_weight is not None:
         inv_mask = jt.logical_not(mask)
         loop_weight = init.constant((N, ), edge_weight.dtype, fill_value)
-        remaining_edge_weight = edge_weight[inv_mask]
+        remaining_edge_weight = _mask_select_1d(edge_weight, inv_mask)
         if remaining_edge_weight.numel() > 0:
-            loop_weight[row[inv_mask]] = remaining_edge_weight
-        edge_weight = jt.concat([edge_weight[mask], loop_weight], dim=0)
+            loop_weight[_mask_select_1d(row, inv_mask)] = remaining_edge_weight
+        edge_weight = jt.concat([_mask_select_1d(edge_weight, mask), loop_weight], dim=0)
 
     return edge_index, edge_weight


### PR DESCRIPTION
## Description / 描述

Fix build errors and runtime failures when running JittorGeometric on non-CUDA platforms (especially Ascend/ACL NPU). Guard platform-specific headers/libraries with conditional compilation, and replace unsupported Jittor kernel calls with host-side NumPy equivalents for small CPU-resident tensors.

## Type of Change / 修改类型

- [x] Bug fix / Bug 修复
- [ ] New feature / 新功能
- [ ] Performance improvement / 性能优化
- [ ] Documentation update / 文档更新
- [ ] Test addition / 添加测试
- [ ] Refactoring (no functional changes) / 重构（无功能性变更）
- [ ] Other (please describe) / 其他（请描述）

## Changes Summary / 修改摘要

- **fix(ops): guard `immintrin.h` include for x86 only** — Wrap `#include <immintrin.h>` with `#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__)` guards across 14 C++ op headers/sources to prevent build failures on ARM (aarch64) machines.

- **fix: fix build errors in non-CUDA environments** — Guard CUDA-related headers and `cusparse_ops` references with conditional compilation macros (`HAS_CUDA`); lazy-load cusparse_ops in `spmmcoo.py` / `spmmcsr.py` to avoid `ImportError` on non-CUDA platforms.

- **fix(acl): make host-side reductions/indexing device-agnostic for Ascend backend** — Several host-side ops on small CPU-resident tensors relied on Jittor kernels that are broken or unsupported on the ACL backend:
  - `temporal_dataloader.py`: Replace `Var.max()` (hits aclnnAmax ERROR 161002 on 1-D int tensors) with `numpy.max()`; replace `Var.unique()` (uses `_cuda`-flagged custom op) with `np.unique()`.
  - `utils/loop.py`: Add `_select_columns_by_mask` / `_mask_select_1d` helpers that perform masked selection via NumPy, working around unsupported `(slice, bool-Var)` mixed indexing on both CPU and ACL backends. Used in `remove_self_loops`, `segregate_self_loops`, and `add_remaining_self_loops`.

## Files Changed (19 files, +77 −11)

| Path | Change |
|------|--------|
| `jittor_geometric/ops/cpp/*.h` / `*.cc` (14 files) | Add `#ifdef __x86_64__` guard around `immintrin.h` |
| `jittor_geometric/ops/spmmcoo.py` | Lazy-load cusparse_ops |
| `jittor_geometric/ops/spmmcsr.py` | Lazy-load cusparse_ops |
| `jittor_geometric/dataloader/temporal_dataloader.py` | Use numpy for max/unique on node ids |
| `jittor_geometric/utils/loop.py` | Add NumPy-based masked select helpers |

## Testing / 测试

- [x] Verified build succeeds on aarch64 × Ascend NPU.
- [x] Verified `temporal_dataloader` and self-loop utilities run correctly on Ascend NPU.
- [x] Existing tests pass on CPU backend.
